### PR TITLE
Replace raw-sockets with direct-sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<img src="https://wicg.github.io/raw-sockets/logo-socket.svg" height="100" align=right>
+<img src="https://wicg.github.io/direct-sockets/logo-socket.svg" height="100" align=right>
 
-# raw-sockets
+# direct-sockets
 
 This is a proposal for a future Direct Sockets web platform API.
 
@@ -8,5 +8,5 @@ This is a proposal for a future Direct Sockets web platform API.
 
 * [Discourse thread](https://discourse.wicg.io/t/filling-the-remaining-gap-between-websocket-webrtc-and-webtranspor/4366)
 * [Explainer document](docs/explainer.md), a high-level overview of the proposal.
-* [Specification](https://wicg.github.io/raw-sockets/)
+* [Specification](https://wicg.github.io/direct-sockets/)
 * [Self-Review Questionnaire: Security and Privacy](docs/security-privacy-self-review.md)

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -1,4 +1,4 @@
-<img src="https://wicg.github.io/raw-sockets/logo-socket.svg" height="100" align=right>
+<img src="https://wicg.github.io/direct-sockets/logo-socket.svg" height="100" align=right>
 
 # Direct Sockets
 

--- a/docs/security-privacy-self-review.md
+++ b/docs/security-privacy-self-review.md
@@ -1,6 +1,6 @@
 
 
-Responses to the [Self-Review Questionnaire: Security and Privacy](https://w3ctag.github.io/security-questionnaire/) for the [Direct Sockets API](https://github.com/WICG/raw-sockets/)
+Responses to the [Self-Review Questionnaire: Security and Privacy](https://w3ctag.github.io/security-questionnaire/) for the [Direct Sockets API](https://github.com/WICG/direct-sockets/)
 
 
 
@@ -23,7 +23,7 @@ Implementors will want to carefully consider what information is revealed in the
 
 This specification deals with generic information.
 
-This specification allows devices to use their existing protocols for communication. These may or may not be secure. We intend to [facilitate](https://github.com/WICG/raw-sockets/blob/master/docs/explainer.md#mitigation-7) use of TLS.
+This specification allows devices to use their existing protocols for communication. These may or may not be secure. We intend to [facilitate](https://github.com/WICG/direct-sockets/blob/master/docs/explainer.md#mitigation-7) use of TLS.
 
 
 ## 2.4 How does this specification deal with sensitive information?

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       var respecConfig = {
         specStatus: "unofficial",
         github: {
-          repoURL: "WICG/raw-sockets",
+          repoURL: "WICG/direct-sockets",
           branch: "main"
         },
         group: "wicg",
@@ -229,7 +229,7 @@
         </h2>
         <ul>
           <li>See <a href=
-          "https://github.com/WICG/raw-sockets/blob/main/docs/explainer.md#security-considerations">
+          "https://github.com/WICG/direct-sockets/blob/main/docs/explainer.md#security-considerations">
             Explainer</a>.
           </li>
         </ul>


### PR DESCRIPTION
The github repo has been renamed. We update hyperlinks.
https://github.com/WICG/direct-sockets/issues/10


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/direct-sockets/pull/36.html" title="Last updated on Dec 22, 2021, 10:09 AM UTC (ae4b302)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/direct-sockets/36/a9c6a1d...ewilligers:ae4b302.html" title="Last updated on Dec 22, 2021, 10:09 AM UTC (ae4b302)">Diff</a>