### PR TITLE
Add Permissions-Policy section

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -48,6 +48,15 @@ Distributed Hash Tables are not an immediate focus. The current proposal would r
 
 IP multicast and UDP Broadcast are currently out of scope.
 
+## Permissions Policy integration
+
+This specification defines a policy-controlled permission identified by the string `direct-sockets`. Its default allowlist is `self`.
+
+```
+Permissions-Policy: direct-sockets=(self)
+```
+
+This [`Permissions-Policy`](https://chromestatus.com/feature/5745992911552512) header determines whether a `navigator.openTCPSocket({...})` or `navigator.openUDPSocket({...})` call immediately rejects with a `NotAllowedError` `DOMException`.
 
 ## Security Considerations
 

--- a/index.html
+++ b/index.html
@@ -234,6 +234,23 @@
           </li>
         </ul>
       </section>
+      <section id="permissions-policy" data-cite="permissions-policy">
+      <h2>
+        Permissions Policy integration
+      </h2>
+      <p>
+        This specification defines a policy-controlled permission identified by
+        the string <code><dfn class="permission">"direct-sockets"</dfn></code>. Its
+        <a>default allowlist</a> is '`self`'.
+      </p>
+      <div class="note">
+        <p>
+          A <a>document</a>’s permission policy determines whether a
+          {{Navigator/openTCPSocket(...)}} or {{Navigator/openUDPSocket(...)}} call immediately rejects with a
+          {{"NotAllowedError"}} {{DOMException}}.
+        </p>
+      </div>
+    </section>
     </section>
   </body>
 </html>


### PR DESCRIPTION
Describe how permissions policy can be set for direct-sockets.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/GrapeGreen/direct-sockets/pull/37.html" title="Last updated on Dec 22, 2021, 3:56 PM UTC (21aaace)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/direct-sockets/37/1923310...GrapeGreen:21aaace.html" title="Last updated on Dec 22, 2021, 3:56 PM UTC (21aaace)">Diff</a>