### PR TITLE
Replace TCPKeepAliveOptions dictionary with separate options

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -178,10 +178,8 @@ const options = {
     remoteAddress: 'example.com',
     remotePort: 7,
     noDelay: false,
-    keepAliveOptions: {
-        enable: true,
-        delay: 720
-    }
+    keepAlive: true,
+    keepAliveDelay: 720_000
 };
 navigator.openTCPSocket(options).then(tcpSocket => { ... }).else(error => { ... });
 ```

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
           dictionary TCPSocketOptions : SocketOptions {
             boolean noDelay;
             boolean keepAlive;
-            [Clamp] unsigned long keepAliveDelay;
+            [EnforceRange] unsigned long keepAliveDelay;
           };
           </pre>
           <p>

--- a/index.html
+++ b/index.html
@@ -137,14 +137,10 @@
             `TCPSocketOptions` dictionary
           </h3>
           <pre class="idl">
-          dictionary TCPKeepAliveOptions {
-            boolean enable;
-            [Clamp] unsigned short delay; 
-          };
-          
           dictionary TCPSocketOptions : SocketOptions {
             boolean noDelay;
-            TCPKeepAliveOptions keepAliveOptions;
+            boolean keepAlive;
+            [Clamp] unsigned long keepAliveDelay;
           };
           </pre>
           <p>
@@ -162,24 +158,17 @@
               algorithm</a>.
             </dd>
             <dt>
-              <dfn>keepAliveOptions</dfn> member
+              <dfn>keepAlive</dfn> member
             </dt>
             <dd>
-              Configures TCP Keep-Alive by setting `SO_KEEPALIVE` option on the socket via <dfn>{{TCPKeepAliveOptions}}</dfn>.
-              <dl data-dfn-for="TCPKeepAliveOptions">
-                <dt> 
-                  <dfn>enable</dfn> member 
-                </dt>
-                <dd> 
-                  Enables/disables TCP Keep-Alive. 
-                </dd>
-                <dt>
-                  <dfn>delay</dfn> member
-                </dt>
-                <dd>
-                  Specifies delay in seconds. Must be supplied if and only if {{TCPKeepAliveOptions/enable}} is true. Negative/overflow values will be clamped to match the `unsigned short` range.
-                </dd>
-              </dl>
+              Enables/disables TCP Keep-Alive by setting `SO_KEEPALIVE` option on the socket. 
+            </dd>
+            <dt>
+              <dfn>keepAliveDelay</dfn> member
+            </dt>
+            <dd>
+              Specifies the Keep-Alive ping delay in milliseconds. Must be specified only if
+              {{TCPSocketOptions/keepAlive}} is set to `true`.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/GrapeGreen/direct-sockets/pull/39.html" title="Last updated on Jan 10, 2022, 6:06 PM UTC (ac56407)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/direct-sockets/39/08d381a...GrapeGreen:ac56407.html" title="Last updated on Jan 10, 2022, 6:06 PM UTC (ac56407)">Diff</a>