### PR TITLE
Replace ArrayBuffer with BufferSource for UDPMessage and explain return types

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -197,9 +197,14 @@ There is currently no provision for setting the local address or port.
 
 ### IO operations
 
-The TCP socket can be used for reading and writing. Both streams operate on the [`BufferSource`](https://developer.mozilla.org/en-US/docs/Web/API/BufferSource) object.
+The TCP socket can be used for reading and writing. 
+- Writable stream accepts [`BufferSource`](https://developer.mozilla.org/en-US/docs/Web/API/BufferSource)
+- Readable stream returns [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
 
 #### Reading
+
+See [`ReadableStream`](https://streams.spec.whatwg.org/#rs-intro) spec for more examples.
+
 ```javascript
 const decoder = new TextDecoder();
 
@@ -218,6 +223,8 @@ let message = decoder.decode(value);
 
 #### Writing
 
+See [`WritableStream`](https://streams.spec.whatwg.org/#ws-intro) spec for more examples.
+
 ```javascript
 const encoder = new TextEncoder();
 
@@ -226,7 +233,10 @@ let writer = writableStream.getWriter();
 
 let message = "Some user-created tcp data";
 
-await writer.write(encoder.encode(message)).catch(err => console.log(err));
+await writer.ready;
+writer.write(
+  encoder.encode(message)
+).catch(err => console.log(err));
 ...
 ```
 
@@ -263,13 +273,17 @@ There is currently no provision for setting the local address or port.
 The UDP socket can be used for reading and writing. Both streams operate on the `UDPMessage` object which is defined as follows (idl):
 ```javascript
 dictionary UDPMessage {
-  ArrayBuffer    data;
+  BufferSource   data;
   DOMString      remoteAddress;
   unsigned short remotePort;
 };
 ```
+- Writable stream accepts `data` as [`BufferSource`](https://developer.mozilla.org/en-US/docs/Web/API/BufferSource)
+- Readable stream returns `data` as [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
 
 #### Reading
+
+See [`ReadableStream`](https://streams.spec.whatwg.org/#rs-intro) spec for more examples.
 
 ```javascript
 const decoder = new TextDecoder();
@@ -293,6 +307,8 @@ let message = decoder.decode(data);
 
 #### Writing
 
+See [`WritableStream`](https://streams.spec.whatwg.org/#ws-intro) spec for more examples.
+
 ```javascript
 const encoder = new TextEncoder();
 
@@ -301,11 +317,16 @@ let writer = writableStream.getWriter();
 
 let message = "Some user-created datagram";
 
-// sends a UDPMessage object.
-await writer.write({
+// sends a UDPMessage object with data = Uint8Array
+await writer.ready;
+writer.write({
+    data: encoder.encode(message)
+}).catch(err => console.log(err));
+
+// or, alternatively, with data = ArrayBuffer
+await writer.ready;
+writer.write({
     data: encoder.encode(message).buffer
 }).catch(err => console.log(err));
 ...
 ```
-Note the `encode(...).buffer` part: the `encode(...)` method returns a [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) that cannot be implicitly converted to [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
-

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
             more information about streams.
           </div>
           <div class="note">
-            {{TCPSocket/readable}} and {{TCPSocket/writable}} operate on the {{BufferSource}} object.
+            {{TCPSocket/writable}} accepts {{BufferSource}}. {{TCPSocket/readable}} returns {{Uint8Array}}.
           </div>
         </section>
         <section data-dfn-for="UDPSocket">
@@ -238,7 +238,7 @@
             </h3>
             <pre class="idl">
             dictionary UDPMessage {
-              ArrayBuffer    data;
+              BufferSource data;
               DOMString      remoteAddress;
               unsigned short remotePort;
             };
@@ -248,7 +248,8 @@
                 <dfn>data</dfn> member
               </dt>
               <dd>
-                The user message represented as an {{ArrayBuffer}}.
+                The user message represented as {{BufferSource}}.
+                Note that for {{UDPSocket/readable}} the underlying type is always {{Uint8Array}}.
               </dd>
               <dt>
                 <dfn>remoteAddress</dfn> member


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/GrapeGreen/direct-sockets/pull/41.html" title="Last updated on Feb 4, 2022, 2:42 PM UTC (e3ba7a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/direct-sockets/41/b087ea9...GrapeGreen:e3ba7a5.html" title="Last updated on Feb 4, 2022, 2:42 PM UTC (e3ba7a5)">Diff</a>