### PR TITLE
Introduce direct-sockets-private permissions policy and impose additional port restrictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
   <script class='remove'>
     var respecConfig = {
-      specStatus: "unofficial",
+      specStatus: "CG-DRAFT",
       github: {
         repoURL: "WICG/direct-sockets",
         branch: "main"

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
           <ol>
             <li>
               If |remoteAddress| resolves to an IP address belonging to the
-              <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a> and [=this=]'s [=relevant global object=]'s [=associated Document=] is
+              [=IP address space/private=] network address space and [=this=]'s [=relevant global object=]'s [=associated Document=] is
               not [=allowed to use=] the [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-private=]", [=queue a global task=] on the [=relevant global
               object=] of
               [=this=] using the [=TCPSocket task source=] to run the
@@ -991,7 +991,7 @@
           <ol>
             <li>
               If the inferred {{UDPSocket/mode}} is {{UDPSocket/connected}} and |remoteAddress| resolves to an IP address belonging to the
-              <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a> and [=this=]'s [=relevant global object=]'s [=associated Document=] is
+              [=IP address space/private=] network address space and [=this=]'s [=relevant global object=]'s [=associated Document=] is
               not [=allowed to use=] the [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-private=]", [=queue a global task=] on the [=relevant global
               object=] of
               [=this=] using the [=UDPSocket task source=] to run the
@@ -2223,9 +2223,7 @@
 
       <p>
         This specification defines a feature that controls whether {{TCPSocket}} and {{UDPSocket}}
-        classes might connect to addresses belonging to the
-        <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a>.
-
+        classes might connect to addresses belonging to the [=IP address space/private=] network address space.
       <p>
         The feature name for this feature is "<dfn
           data-dfn-for="policy-controlled feature"><code>direct-sockets-private</code></dfn>"`.
@@ -2241,11 +2239,11 @@
         <ul>
           <li>
             For {{TCPSocket}}, the {{TCPSocket/[[openedPromise]]}} will be rejected if the resolved address belongs to the
-            <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a>.
+            [=IP address space/private=] network address space.
           <li>
             For {{UDPSocket}} in {{UDPSocket/connected}} {{UDPSocket/mode}}, the {{UDPSocket/[[openedPromise]]}}
             will be rejected if the resolved address belongs to the
-            <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a>.
+            [=IP address space/private=] network address space.
           <li>
             For {{UDPSocket}} in {{UDPSocket/bound}} {{UDPSocket/mode}}, the {{UDPSocket/[[openedPromise]]}}
             will be rejected unconditionally.

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         },
       ],
       latestVersion: null,
-      xref: ["web-platform", "streams", "permissions-policy", "HTML", "infra", "DOM", "webidl", "isolated-contexts"],
+      xref: ["web-platform", "streams", "permissions-policy", "HTML", "infra", "DOM", "webidl", "isolated-contexts", "private-network-access"],
       // eventually add mdn: true, and caniuse: "direct-sockets"
     };
   </script>
@@ -154,10 +154,25 @@
           Perform the following steps [=in parallel=].
           <ol>
             <li>
+              If |remoteAddress| resolves to an IP address belonging to the
+              <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a> and [=this=]'s [=relevant global object=]'s [=associated Document=] is
+              not [=allowed to use=] the [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-private=]", [=queue a global task=] on the [=relevant global
+              object=] of
+              [=this=] using the [=TCPSocket task source=] to run the
+              following steps:
+              <ol>
+                <li>
+                  [=Reject=] the {{TCPSocket/[[openedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+                <li>
+                  [=Reject=] the {{TCPSocket/[[closedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+              </ol>
+            <li>
               Invoke the operating system to open a TCP socket using the given |remoteAddress| and
               |remotePort| and the connection parameters (or their defaults) specified in |options|.
             <li>
-              If this fails for any reason, [=queue a global task=] on the [=relevant global
+              If this fails for any other reason, [=queue a global task=] on the [=relevant global
               object=] of
               [=this=] using the [=TCPSocket task source=] to run the
               following steps:
@@ -974,6 +989,39 @@
         <li>
           Perform the following steps [=in parallel=].
           <ol>
+            <li>
+              If the inferred {{UDPSocket/mode}} is {{UDPSocket/connected}} and |remoteAddress| resolves to an IP address belonging to the
+              <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a> and [=this=]'s [=relevant global object=]'s [=associated Document=] is
+              not [=allowed to use=] the [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-private=]", [=queue a global task=] on the [=relevant global
+              object=] of
+              [=this=] using the [=UDPSocket task source=] to run the
+              following steps:
+              <ol>
+                <li>
+                  [=Reject=] the {{UDPSocket/[[openedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+                <li>
+                  [=Reject=] the {{UDPSocket/[[closedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+              </ol>
+            <li>
+              If the inferred {{UDPSocket/mode}} is {{UDPSocket/bound}} and either [=this=]'s [=relevant global object=]'s [=associated Document=] is
+              not [=allowed to use=] the [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-private=]"
+              or the requested |localPort| is less than 1024, [=queue a global task=] on the [=relevant global object=] of
+              [=this=] using the [=UDPSocket task source=] to run the
+              following steps:
+              <ol>
+                <li>
+                  [=Reject=] the {{UDPSocket/[[openedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+                <li>
+                  [=Reject=] the {{UDPSocket/[[closedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+              </ol>
+
+              <div class="note">
+                While these conditions could technically be checked at construction time, they're deliberately addressed here to unify the behavior with {{UDPSocket/connected}} {{UDPSocket/mode}}.
+              </div>
             <li>
               Invoke the operating system to open a UDP socket using the inferred
               {{UDPSocket/mode}} and the parameters (or their defaults) specified in |options|.
@@ -1814,6 +1862,21 @@
           Perform the following steps [=in parallel=].
           <ol>
             <li>
+              If the requested |localPort| is less than 32678, [=queue a global task=] on the [=relevant global object=] of
+              [=this=] using the [=TCPServerSocket task source=] to run the following steps:
+              <ol>
+                <li>
+                  [=Reject=] the {{TCPServerSocket/[[openedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+                <li>
+                  [=Reject=] the {{TCPServerSocket/[[closedPromise]]}} with a "{{NotAllowedError}}"
+                  {{DOMException}}.
+              </ol>
+              <div class="note">
+                While this condition could technically be checked at construction time, it's deliberately addressed here
+                to allow for potentially loosening it with additional user-facing permissions.
+              </div>
+            <li>
               Invoke the operating system to open a TCP server socket using the given |localAddress|
               and the connection parameters (or their defaults) specified in |options|.
             <li>
@@ -2137,20 +2200,56 @@
       <h3>Permissions Policy</h3>
 
       <p>
-        This specification defines a feature that controls whether {{TCPSocket}} and {{UDPSocket}}
-        classes may be created.
+        This specification defines a feature that controls whether {{TCPSocket}}, {{UDPSocket}}
+        and {{TCPServerSocket}} classes may be created.
 
       <p>
         The feature name for this feature is "<dfn
           data-dfn-for="policy-controlled feature"><code>direct-sockets</code></dfn>"`.
 
       <p>
-        The default allowlist for this feature is `'self'`.
+        The default allowlist for this feature is `'none'`.
 
       <div class="note">
         A document’s permission policy determines whether a
         `new TCPSocket(...)`, `new UDPSocket(...)` or `new TCPServerSocket(...)` call rejects with
         a {{"NotAllowedError"}} {{DOMException}}.
+      </div>
+
+    </section>
+
+    <section id="permissions-policy-pna">
+      <h3>Permissions Policy (Private Network Access)</h3>
+
+      <p>
+        This specification defines a feature that controls whether {{TCPSocket}} and {{UDPSocket}}
+        classes might connect to addresses belonging to the
+        <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a>.
+
+      <p>
+        The feature name for this feature is "<dfn
+          data-dfn-for="policy-controlled feature"><code>direct-sockets-private</code></dfn>"`.
+
+      <p>
+        The default allowlist for this feature is `'none'`.
+
+      <div class="note">
+        A document’s permission policy determines whether a {{TCPSocket}}
+        {{TCPSocket/[[openedPromise]]}} or {{UDPSocket}} {{UDPSocket/[[openedPromise]]}} promise rejects with
+        a {{"NotAllowedError"}} {{DOMException}}.
+
+        <ul>
+          <li>
+            For {{TCPSocket}}, the {{TCPSocket/[[openedPromise]]}} will be rejected if the resolved address belongs to the
+            <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a>.
+          <li>
+            For {{UDPSocket}} in {{UDPSocket/connected}} {{UDPSocket/mode}}, the {{UDPSocket/[[openedPromise]]}}
+            will be rejected if the resolved address belongs to the
+            <a href="https://wicg.github.io/private-network-access/#ip-address-space-private">private network address space</a>.
+          <li>
+            For {{UDPSocket}} in {{UDPSocket/bound}} {{UDPSocket/mode}}, the {{UDPSocket/[[openedPromise]]}}
+            will be rejected unconditionally.
+        </ul>
       </div>
 
     </section>


### PR DESCRIPTION
This change outlines the direct-sockets-private permissions policy that roughly applies as follows:
- For `TCPSocket`, if the destination address resolves to [private](https://wicg.github.io/private-network-access/#ip-address-space-private)
- For `UDPSocket` (connected mode), if the destination address resolves to [private](https://wicg.github.io/private-network-access/#ip-address-space-private)
- For `UDPSocket` (bound mode), always

On top of that, new port range restrictions are applied:
- For `TCPServerSocket`, ports below 32678 are prohibited
- For `UDPSocket` (bound mode), ports below 1024 are prohibited


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/GrapeGreen/direct-sockets/pull/74.html" title="Last updated on Oct 24, 2024, 9:19 AM UTC (e68a417)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/direct-sockets/74/1a6a844...GrapeGreen:e68a417.html" title="Last updated on Oct 24, 2024, 9:19 AM UTC (e68a417)">Diff</a>