### PR TITLE
Sending udp to multicast address requires permission policy.

### DIFF
--- a/docs/multicast-explainer.md
+++ b/docs/multicast-explainer.md
@@ -73,11 +73,17 @@ This specification defines a policy-controlled permission identified by the stri
 ```
 Permissions-Policy: direct-sockets-multicast=(self)
 ```
-This [`Permissions-Policy`](https://chromestatus.com/feature/5745992911552512) header determines whether 
-`multicastController.joinGroup()`, `multicastController.leaveGroup()` call or providing multicast params to
-`new UDPSocket(..)` immediately rejects with SecurityError.
+This [`Permissions-Policy`](https://chromestatus.com/feature/5745992911552512) header determines whether the following operations are allowed or rejected with `DOMException.NotAllowedError`:
 
-* In a similar fashion, Apple requires that apps with multicast declare [multicast entitlment](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.networking.multicast). 
+* `multicastController.joinGroup()`, `multicastController.leaveGroup()` call.
+* Providing multicast params to `new UDPSocket(..)`. 
+* Sending UDP datagrams to a multicast address via `new UDPSocket(multicastRemoteAdd, ...)` or `writer.write({
+    data: ...,
+    remoteAddress: multicastAddress,
+    remotePort: ...
+})`
+
+In a similar fashion, Apple requires that apps with multicast declare [multicast entitlment](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.networking.multicast). 
 
 ## Sending datagrams example
 

--- a/index.html
+++ b/index.html
@@ -944,7 +944,9 @@
         <li>
           If any of |options|["{{UDPSocketOptions/multicastTimeToLive}}"],
           |options|["{{UDPSocketOptions/multicastLoopback}}"],
-          or |options|["{{UDPSocketOptions/multicastAllowAddressSharing}}"] is specified, and [=this=]'s [=relevant
+          or |options|["{{UDPSocketOptions/multicastAllowAddressSharing}}"] is specified,
+          or |options|["{{UDPSocketOptions/remoteAddress}}"] is a valid multicast address (IPv4: 224.0.0.0/4 or IPv6: ff00::/8),
+          and [=this=]'s [=relevant
           global object=]'s [=associated Document=] is not [=allowed to use=] the 
           [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-multicast=]",
            throw a "{{NotAllowedError}}" {{DOMException}}.
@@ -1488,6 +1490,11 @@
               or |message|["{{UDPMessage/remotePort}}"] <b>is not specified</b> in
               {{UDPSocket/bound}} {{UDPSocket/mode}}, reject |promise| with a
               {{TypeError}} and return |promise|.
+            <li>
+              If |message|["{{UDPMessage/remoteAddress}}"] is a valid multicast address (IPv4: 224.0.0.0/4 or IPv6: ff00::/8),
+              and [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=allowed to use=] the 
+              [=policy-controlled feature=] named "[=policy-controlled feature/direct-sockets-multicast=]",
+              reject |promise| with a "{{NotAllowedError}}" {{DOMException}} and return |promise|.
             <li>
               [=Get a copy of the buffer source=] |message|["{{UDPMessage/data}}"] and save the
               result in |bytes|.
@@ -2596,7 +2603,7 @@
 
       <p>
         This specification defines a feature that controls whether an application can
-        receive multicast packets using {{UDPSocket}} and {{MulticastController}}.
+        send and receive multicast packets using {{UDPSocket}} and {{MulticastController}}.
       <p>
         The feature name for this feature is "<dfn
           data-dfn-for="policy-controlled feature"><code>direct-sockets-multicast</code></dfn>"`.
@@ -2611,13 +2618,19 @@
           <li>
             If an application without the permission attempts to construct a {{UDPSocket}}
             with the {{UDPSocketOptions/multicastTimeToLive}}, {{UDPSocketOptions/multicastLoopback}},
-            or {{UDPSocketOptions/multicastAllowAddressSharing}} members set, the constructor will throw a
+            {{UDPSocketOptions/multicastAllowAddressSharing}} members set, or a {{UDPSocketOptions/remoteAddress}}
+            that is a valid multicast address, the constructor will throw a
             "{{NotAllowedError}}" {{DOMException}}.
           </li>
           <li>
             If an application without the permission successfully opens a {{UDPSocket}} in {{UDPSocket/bound}} mode,
             the returned {{UDPSocketOpenInfo}} dictionary will not contain the
             {{UDPSocketOpenInfo/multicastController}} member.
+          </li>
+          <li>
+            If an application without the permission attempts to write a {{UDPMessage}}
+            with a {{UDPMessage/remoteAddress}} that is a valid multicast address, the promise will reject with a
+            "{{NotAllowedError}}" {{DOMException}}.
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Also fix previously wrong stated SecurityException -> NotAllowedError.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vkrot-cell/direct-sockets/pull/85.html" title="Last updated on Jul 10, 2026, 1:48 PM UTC (8bad461)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/direct-sockets/85/add094c...vkrot-cell:8bad461.html" title="Last updated on Jul 10, 2026, 1:48 PM UTC (8bad461)">Diff</a>